### PR TITLE
Clear (blank) the layer before updating

### DIFF
--- a/lib/qr-layer.c
+++ b/lib/qr-layer.c
@@ -1,12 +1,7 @@
 #include <pebble.h>
 #include "qr-layer.h"
-#include <QR_Encode.h>
 
-typedef struct QRData {
-  unsigned char str[MAX_BITDATA];
-  uint8_t width;
-} QRData;
-
+static void clear(Layer* layer, GContext* ctx);
 static void update(Layer* layer, GContext* ctx);
 
 QRLayer* qr_layer_create(GRect bounds) {
@@ -33,9 +28,20 @@ Layer* qr_layer_get_layer(QRLayer* layer) {
   return (Layer*)layer;
 }
 
+static void clear(Layer* layer, GContext* ctx) {
+  GRect layer_size = layer_get_bounds(layer);
+  graphics_context_set_fill_color(ctx, DEFAULT_BG_COLOR);
+  graphics_fill_rect(ctx, layer_size, 0, GCornerNone);
+  graphics_context_set_fill_color(ctx, DEFAULT_FILL_COLOR);
+}
+
 static void update(Layer* layer, GContext* ctx) {
+  GRect layer_size = layer_get_bounds(layer);
+
+  clear(layer, ctx);
+
   QRData* qr_data = (QRData*) layer_get_data(layer);
-  
+
   if (qr_data->width == 0) {
     return;
   }
@@ -43,7 +49,6 @@ static void update(Layer* layer, GContext* ctx) {
 	uint8_t byte = 0;
 	uint8_t bit = 7;
 
-	GRect layer_size = layer_get_bounds(layer);
 	uint8_t block_size = layer_size.size.w / qr_data->width;
 	uint8_t padding_x = (layer_size.size.w - (block_size * qr_data->width)) / 2;
 	uint8_t padding_y = (layer_size.size.h - (block_size * qr_data->width)) / 2;

--- a/lib/qr-layer.h
+++ b/lib/qr-layer.h
@@ -1,6 +1,16 @@
 #pragma once
 
 #include <pebble.h>
+#include "QR_Encode.h"
+
+#define DEFAULT_BG_COLOR GColorWhite
+
+#define DEFAULT_FILL_COLOR GColorBlack
+
+typedef struct QRData {
+  unsigned char str[MAX_BITDATA];
+  uint8_t width;
+} QRData;
 
 typedef Layer QRLayer;
 


### PR DESCRIPTION
In a project of mine I have a window containing 2 text layers (like header and footer), and in between I have the QR layer. I always had a valid QR displayed upon creation, but it always became invalid (ie. no reader could read it) when I tried to update it (using qr_layer_set_data). 
After a bit of playing I realized that "clearing" the GRect first helps. My patch basically fills the GRect with a pre-defined BG color, and then sets the fill color back to "black". Unfortunately I could not find a call to read the fill colors, so therefore I defined them in the header. I don't like this part, but well, works for me.. 

I really like the idea of using a new layer for this purpose. Thank you for this great lib!!
